### PR TITLE
Add React and TypeScript sprint tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Node artifacts
+node_modules/
+*.log
+# MacOS
+.DS_Store
+# Build output
+/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# sprinting
+# Sprinting
+
+A simple web tool to kick off a sprint for a development team. Data is stored locally in your browser as a JSON object.
+
+## Features
+
+- Manage a list of team members.
+- Configure basic sprint information (name and dates).
+- Data is saved to `localStorage` so it persists between sessions.
+
+## Usage
+
+Build the TypeScript sources and open `index.html` in your browser. Use the `+` buttons to add team members and configure the current sprint.
+
+## Development
+
+This project uses React and TypeScript without a bundler. Compile the sources with `tsc`:
+
+```bash
+npm install -g typescript # if not already installed
+tsc
+```
+
+The compiled files are placed in `dist/`. Then open `index.html` to run the app.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sprint Kickoff</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    header { background: #2c3e50; color: white; padding: 1rem; text-align: center; }
+    section { margin: 1rem; }
+    h2 { margin-top: 2rem; }
+    button { margin-left: 0.5rem; }
+    ul { list-style: none; padding: 0; }
+    li { background: #ecf0f1; margin: 0.25rem 0; padding: 0.5rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script type="module" src="./dist/index.js"></script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+
+interface SprintData {
+  name: string;
+  start: string;
+  end: string;
+}
+
+interface Data {
+  team: string[];
+  sprint: SprintData | null;
+}
+
+const STORAGE_KEY = 'sprintingData';
+
+const App = () => {
+  const [team, setTeam] = useState([] as string[]);
+  const [sprint, setSprint] = useState(null as SprintData | null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const data: Data = JSON.parse(stored);
+        setTeam(data.team || []);
+        setSprint(data.sprint || null);
+      } catch (err) {
+        console.error('Failed to parse stored data', err);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const data: Data = { team, sprint };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }, [team, sprint]);
+
+  const addMember = () => {
+    const name = prompt('Team member name:');
+    if (name) {
+      setTeam([...team, name]);
+    }
+  };
+
+  const configureSprint = () => {
+    const name = prompt('Sprint name:');
+    if (!name) return;
+    const start = prompt('Start date (YYYY-MM-DD):');
+    if (!start) return;
+    const end = prompt('End date (YYYY-MM-DD):');
+    if (!end) return;
+    setSprint({ name, start, end });
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>Sprint Kickoff</h1>
+      </header>
+
+      <section>
+        <h2>
+          My Team <button onClick={addMember}>+</button>
+        </h2>
+        <ul>
+          {team.map((member, idx) => (
+            <li key={idx}>{member}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2>
+          This Sprint <button onClick={configureSprint}>+</button>
+        </h2>
+        <div>
+          {sprint && (
+            <p>
+              {`${sprint.name} (${sprint.start} - ${sprint.end})`}
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = document.getElementById('root');
+if (root) {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/src/shims-react.d.ts
+++ b/src/shims-react.d.ts
@@ -1,0 +1,9 @@
+declare module 'react';
+declare module 'react-dom/client';
+declare module 'react/jsx-runtime';
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES6",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "strict": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- convert simple web app to React with TypeScript
- store team and sprint data in localStorage
- document how to build with `tsc`

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68483ae7336083338a7861789c5edc41