### PR TITLE
Add npm build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Build the TypeScript sources and open `index.html` in your browser. Use the `+` 
 
 ## Development
 
-This project uses React and TypeScript without a bundler. Compile the sources with `tsc`:
+This project uses React and TypeScript without a bundler. Install the dependencies and run the build script:
 
 ```bash
-npm install -g typescript # if not already installed
-tsc
+npm install
+npm run build
 ```
 
 The compiled files are placed in `dist/`. Then open `index.html` to run the app.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "sprinting",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}


### PR DESCRIPTION
## Summary
- create a new `package.json`
- document install and build steps in the README

## Testing
- `npm run build` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68486664d1848333bdc73f3d5d0956aa